### PR TITLE
Add dynamic row management for mappings

### DIFF
--- a/mapping_portal/myapps/mappings/templates/mappings/home.html
+++ b/mapping_portal/myapps/mappings/templates/mappings/home.html
@@ -1,0 +1,225 @@
+{% extends "mappingmaintain.html" %}
+
+{% block title %}Home - Mapping Portal{% endblock %}
+
+{% block content %}
+<style>
+    body {
+        overflow-x: hidden;
+    }
+    .left-panel {
+        padding-left: 0;
+        padding-right: 5px;
+        max-width: 250px;
+    }
+    .scrollable-table-container {
+        overflow-x: auto;
+        overflow-y: auto;
+        max-height: 70vh;
+    }
+    table {
+        font-size: 0.85rem;
+    }
+</style>
+
+<!-- Navigation Menu Button -->
+<button class="btn btn-light btn-sm mb-3" type="button" data-bs-toggle="offcanvas" data-bs-target="#navDrawer">
+    ☰ Menu
+</button>
+
+<!-- Offcanvas Navigation Panel -->
+<div class="offcanvas offcanvas-start" tabindex="-1" id="navDrawer" aria-labelledby="navDrawerLabel">
+    <div class="offcanvas-header">
+        <h5 class="offcanvas-title" id="navDrawerLabel">Navigation</h5>
+        <button type="button" class="btn-close text-reset" data-bs-dismiss="offcanvas"></button>
+    </div>
+    <div class="offcanvas-body">
+        <ul class="list-group">
+            <li class="list-group-item"><a href="{% url 'mappings:home' %}">🏠 Home</a></li>
+            <li class="list-group-item"><a href="{% url 'mappingmaintain:upload_mapping' %}">⬆️ Upload Mapping</a></li>
+            <li class="list-group-item"><a href="{% url 'mappingmaintain:export_mapping' %}">📤 Export Mapping</a></li>
+        </ul>
+    </div>
+</div>
+
+<div class="row">
+    <!-- LEFT PANEL: App & File Tree -->
+    <div class="col-md-3 left-panel border-end">
+        <h6 class="mt-2"><strong>Applications & Files</strong></h6>
+        <div class="accordion" id="fileAccordion">
+            {% for app_code, files in appcode_files.items %}
+            <div class="accordion-item">
+                <h2 class="accordion-header" id="heading{{ forloop.counter }}">
+                    <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse"
+                            data-bs-target="#collapse{{ forloop.counter }}">
+                        {{ app_code }}
+                    </button>
+                </h2>
+                <div id="collapse{{ forloop.counter }}" class="accordion-collapse collapse">
+                    <div class="accordion-body p-0">
+                        <ul class="list-group list-group-flush">
+                            {% for file in files %}
+                            <li class="list-group-item">
+                                📄 <a href="{% url 'mappings:home' %}?file={{ file }}">{{ file }}</a>
+                            </li>
+                            {% endfor %}
+                        </ul>
+                    </div>
+                </div>
+            </div>
+            {% endfor %}
+        </div>
+    </div>
+
+    <!-- RIGHT PANEL: JoinConditions and Mappings -->
+    <div class="col-md-9">
+        {% if joins or mappings %}
+        <h5 class="mt-2">Editing File: <code>{{ selected_file }}</code></h5>
+
+        <form method="post">
+            {% csrf_token %}
+
+            {% if joins %}
+            <h6 class="mt-4">🔗 Join Conditions</h6>
+            <div class="scrollable-table-container">
+                <table class="table table-bordered table-striped">
+                    <thead class="table-light">
+                        <tr>
+                            <th>Mapping Ref Name</th>
+                            <th>Table 1</th>
+                            <th>Table 2</th>
+                            <th>Join Condition</th>
+                            <th>Actions</th>
+                        </tr>
+                    </thead>
+                    <tbody id="joinTableBody">
+                        {% for join in joins %}
+                        <tr>
+                            <td><input name="join_{{ join.pk }}_mapping_ref_name" class="form-control form-control-sm" value="{{ join.mapping_ref_name }}"></td>
+                            <td><input name="join_{{ join.pk }}_table_1" class="form-control form-control-sm" value="{{ join.table_1 }}"></td>
+                            <td><input name="join_{{ join.pk }}_table_2" class="form-control form-control-sm" value="{{ join.table_2 }}"></td>
+                            <td><input name="join_{{ join.pk }}_join" class="form-control form-control-sm" value="{{ join.join }}"></td>
+                            <td>
+                                <input type="hidden" name="join_{{ join.pk }}_status" value="active">
+                                <button type="button" class="btn btn-danger btn-sm delete-row">Delete</button>
+                            </td>
+                        </tr>
+                        {% endfor %}
+                        <!-- Template row for new join conditions -->
+                        <tr class="join-template d-none">
+                            <td><input name="join_new_0_mapping_ref_name" class="form-control form-control-sm"></td>
+                            <td><input name="join_new_0_table_1" class="form-control form-control-sm"></td>
+                            <td><input name="join_new_0_table_2" class="form-control form-control-sm"></td>
+                            <td><input name="join_new_0_join" class="form-control form-control-sm"></td>
+                            <td>
+                                <input type="hidden" name="join_new_0_status" value="active">
+                                <button type="button" class="btn btn-danger btn-sm delete-row">Delete</button>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+                <button type="button" id="addJoinRow" class="btn btn-secondary btn-sm mt-2">Add Row</button>
+            </div>
+            {% endif %}
+
+            {% if mappings %}
+            <h6 class="mt-4">📊 Mapping Definitions</h6>
+            <div class="scrollable-table-container">
+                <table class="table table-bordered table-striped">
+                    <thead class="table-light">
+                        <tr>
+                            <th>Target App</th>
+                            <th>Target Table</th>
+                            <th>Target Column (Physical)</th>
+                            <th>Source App</th>
+                            <th>Source Table</th>
+                            <th>Source Column (Physical)</th>
+                            <th>Actions</th>
+                        </tr>
+                    </thead>
+                    <tbody id="mappingTableBody">
+                        {% for map in mappings %}
+                        <tr>
+                            <td><input name="mapping_{{ map.s_no }}_target_app_code" class="form-control form-control-sm" value="{{ map.target_app_code }}"></td>
+                            <td><input name="mapping_{{ map.s_no }}_target_table_name" class="form-control form-control-sm" value="{{ map.target_table_name }}"></td>
+                            <td><input name="mapping_{{ map.s_no }}_target_column_name_physical" class="form-control form-control-sm" value="{{ map.target_column_name_physical }}"></td>
+                            <td><input name="mapping_{{ map.s_no }}_source_app_code" class="form-control form-control-sm" value="{{ map.source_app_code }}"></td>
+                            <td><input name="mapping_{{ map.s_no }}_source_table_name" class="form-control form-control-sm" value="{{ map.source_table_name }}"></td>
+                            <td><input name="mapping_{{ map.s_no }}_source_column_name_physical" class="form-control form-control-sm" value="{{ map.source_column_name_physical }}"></td>
+                            <td>
+                                <input type="hidden" name="mapping_{{ map.s_no }}_country_applicability" value="{{ map.country_applicability }}">
+                                <input type="hidden" name="mapping_{{ map.s_no }}_status" value="active">
+                                <button type="button" class="btn btn-danger btn-sm delete-row">Delete</button>
+                            </td>
+                        </tr>
+                        {% endfor %}
+                        <!-- Template row for new mappings -->
+                        <tr class="mapping-template d-none">
+                            <td><input name="mapping_new_0_target_app_code" class="form-control form-control-sm"></td>
+                            <td><input name="mapping_new_0_target_table_name" class="form-control form-control-sm"></td>
+                            <td><input name="mapping_new_0_target_column_name_physical" class="form-control form-control-sm"></td>
+                            <td><input name="mapping_new_0_source_app_code" class="form-control form-control-sm"></td>
+                            <td><input name="mapping_new_0_source_table_name" class="form-control form-control-sm"></td>
+                            <td><input name="mapping_new_0_source_column_name_physical" class="form-control form-control-sm"></td>
+                            <td>
+                                <input type="hidden" name="mapping_new_0_country_applicability" value="">
+                                <input type="hidden" name="mapping_new_0_status" value="active">
+                                <button type="button" class="btn btn-danger btn-sm delete-row">Delete</button>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+                <button type="button" id="addMappingRow" class="btn btn-secondary btn-sm mt-2">Add Row</button>
+            </div>
+            {% endif %}
+            <button class="btn btn-primary mt-3">💾 Save Changes</button>
+        </form>
+        {% else %}
+        <div class="alert alert-info mt-4">📂 Select a mapping file from the left to view/edit.</div>
+        {% endif %}
+    </div>
+</div>
+
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    function addRow(templateSelector, tableBodySelector) {
+        const template = document.querySelector(templateSelector);
+        const tbody = document.querySelector(tableBodySelector);
+        let index = tbody.dataset.index ? parseInt(tbody.dataset.index) + 1 : 0;
+        tbody.dataset.index = index;
+        const clone = template.cloneNode(true);
+        clone.classList.remove('d-none', templateSelector.replace('.', ''));
+        clone.querySelectorAll('input').forEach(function(input) {
+            if (input.name) {
+                input.name = input.name.replace('new_0_', `new_${index}_`);
+            }
+            if (input.type !== 'hidden') {
+                input.value = '';
+            } else if (input.value === 'active') {
+                input.value = 'active';
+            }
+        });
+        tbody.appendChild(clone);
+    }
+
+    document.getElementById('addJoinRow')?.addEventListener('click', function() {
+        addRow('.join-template', '#joinTableBody');
+    });
+
+    document.getElementById('addMappingRow')?.addEventListener('click', function() {
+        addRow('.mapping-template', '#mappingTableBody');
+    });
+
+    document.addEventListener('click', function(e) {
+        if (e.target.classList.contains('delete-row')) {
+            const row = e.target.closest('tr');
+            const statusInput = row.querySelector('input[name$="_status"]');
+            if (statusInput) {
+                statusInput.value = 'inactive';
+            }
+            row.style.display = 'none';
+        }
+    });
+});
+</script>
+{% endblock %}

--- a/mapping_portal/myapps/mappings/views.py
+++ b/mapping_portal/myapps/mappings/views.py
@@ -1,0 +1,217 @@
+from django.shortcuts import render, redirect
+from myapps.accounts.models import UserData
+from myapps.mappings.forms import CustomLoginForm
+from myapps.mappingmaintain.models import JoinConditions, ApplicationCode, Mappings, MappingAudit
+from django.utils import timezone
+from django.contrib import messages
+
+
+
+def login(request):
+    print("✅ login view called")
+    return render(request,'myapps/mappings/templates/mappings/login.html')
+def home(request):
+    return render(request,'myapps/mappings/templates/mappings/home.html')
+def news(request):
+    return render(request,'myapps/mappings/templates/mappings/news.html')
+def contact(request):
+    return render(request,'myapps/mappings/templates/mappings/contact.html')
+def about(request):
+    return render(request,'myapps/mappings/templates/mappings/about.html')
+
+##Login user validation
+
+def custom_login(request):
+    print("✅ custom_login view called")
+    error = None
+
+    if request.method == 'POST':
+        form = CustomLoginForm(request.POST)
+        if form.is_valid():
+            lan_id = form.cleaned_data['lan_id']
+            password = form.cleaned_data['password']
+
+            try:
+                user = UserData.objects.get(user_id=lan_id, password=password)
+                request.session['user_id'] = user.user_id
+                print("✅ LOGIN OK:", lan_id)
+                return redirect('mappings:home')
+            except UserData.DoesNotExist:
+                print("❌ User not found")
+                error = "Invalid LAN ID or password."
+        else:
+            print("Form is invalid:", form.errors)
+    else:
+        form = CustomLoginForm()
+
+    return render(request, 'mappings/login.html', {'form': form, 'error': error})
+
+def home(request):
+    if 'user_id' not in request.session:
+        return redirect('custom_login')
+
+    print("✅ Entered home view")
+
+    # Build a dictionary {app_code: [file1, file2]} using target_app_code
+    appcode_files = {}
+    files = Mappings.objects.values_list('uploaded_file', 'target_app_code').distinct()
+    print(f"🔍 Found mapping files: {files}")
+    for file_name, app_code in files:
+        if app_code not in appcode_files:
+            appcode_files[app_code] = []
+        appcode_files[app_code].append(file_name)
+
+    selected_file = request.GET.get('file')
+    print(f"📂 Selected file from request: {selected_file}")
+
+    mappings = Mappings.objects.filter(uploaded_file=selected_file) if selected_file else None
+    joins = JoinConditions.objects.filter(uploaded_file=selected_file) if selected_file else None
+
+    print(f"📊 Fetched {mappings.count() if mappings else 0} mappings")
+    print(f"🔗 Fetched {joins.count() if joins else 0} join conditions")
+
+    if request.method == 'POST':
+        user_id = request.session.get('user_id', 'unknown')
+
+        # --- Update JoinConditions ---
+        if joins:
+            for join in joins:
+                prefix = f"join_{join.pk}"
+                status = request.POST.get(f"{prefix}_status", "active")
+                if status == 'inactive':
+                    join.status = 'inactive'
+                    join.save()
+                    continue
+
+                new_mapping_ref_name = request.POST.get(f"{prefix}_mapping_ref_name", "").strip()
+                new_table_1 = request.POST.get(f"{prefix}_table_1", "").strip()
+                new_table_2 = request.POST.get(f"{prefix}_table_2", "").strip()
+                new_join = request.POST.get(f"{prefix}_join", "").strip()
+
+                if (
+                    join.mapping_ref_name != new_mapping_ref_name or
+                    join.table_1 != new_table_1 or
+                    join.table_2 != new_table_2 or
+                    join.join != new_join
+                ):
+                    join.mapping_ref_name = new_mapping_ref_name
+                    join.table_1 = new_table_1
+                    join.table_2 = new_table_2
+                    join.join = new_join
+                    join.save()
+
+                    MappingAudit.objects.create(
+                        app_code=request.POST.get('app_code', ''),
+                        uploaded_file=selected_file,
+                        action='update',
+                        performed_by=user_id,
+                        remarks=f'JoinConditions updated for file {selected_file}'
+                    )
+
+        # --- Create new JoinConditions ---
+        join_new_indices = set()
+        for key in request.POST.keys():
+            if key.startswith('join_new_') and key.endswith('_mapping_ref_name'):
+                join_new_indices.add(key.split('_')[2])
+        for idx in join_new_indices:
+            prefix = f"join_new_{idx}"
+            if request.POST.get(f"{prefix}_status") == 'inactive':
+                continue
+            JoinConditions.objects.create(
+                uploaded_file=selected_file,
+                jc_s_no=str(JoinConditions.objects.filter(uploaded_file=selected_file).count() + 1),
+                mapping_ref_name=request.POST.get(f"{prefix}_mapping_ref_name", ""),
+                table_1=request.POST.get(f"{prefix}_table_1", ""),
+                table_2=request.POST.get(f"{prefix}_table_2", ""),
+                join=request.POST.get(f"{prefix}_join", ""),
+                status='active'
+            )
+
+        # --- Update Mappings ---
+        if mappings:
+            for mapping in mappings:
+                prefix = f"mapping_{mapping.s_no}"
+                status = request.POST.get(f"{prefix}_status", "active")
+                if status == 'inactive':
+                    mapping.status = 'inactive'
+                    mapping.save()
+                    continue
+                updated = False
+
+                new_values = {
+                    "target_app_code": request.POST.get(f"{prefix}_target_app_code", "").strip(),
+                    "target_table_name": request.POST.get(f"{prefix}_target_table_name", "").strip(),
+                    "target_column_name_physical": request.POST.get(f"{prefix}_target_column_name_physical", "").strip(),
+                    "source_app_code": request.POST.get(f"{prefix}_source_app_code", "").strip(),
+                    "source_table_name": request.POST.get(f"{prefix}_source_table_name", "").strip(),
+                    "country_applicability": request.POST.get(f"{prefix}_country_applicability", "").strip(),
+                    "source_column_name_physical": request.POST.get(f"{prefix}_source_column_name_physical", "").strip(),
+                }
+
+                for field, new_value in new_values.items():
+                    if getattr(mapping, field) != new_value:
+                        setattr(mapping, field, new_value)
+                        updated = True
+
+                if updated:
+                    mapping.save()
+                    MappingAudit.objects.create(
+                        app_code=request.POST.get('app_code', ''),
+                        uploaded_file=selected_file,
+                        action='update',
+                        performed_by=user_id,
+                        remarks=f'Mapping fields updated for file {selected_file}'
+                    )
+
+        # --- Create new Mappings ---
+        mapping_new_indices = set()
+        for key in request.POST.keys():
+            if key.startswith('mapping_new_') and key.endswith('_target_app_code'):
+                mapping_new_indices.add(key.split('_')[2])
+        for idx in mapping_new_indices:
+            prefix = f"mapping_new_{idx}"
+            if request.POST.get(f"{prefix}_status") == 'inactive':
+                continue
+            Mappings.objects.create(
+                uploaded_file=selected_file,
+                s_no=str(Mappings.objects.filter(uploaded_file=selected_file).count() + 1),
+                target_app_code=request.POST.get(f"{prefix}_target_app_code", ""),
+                target_table_name=request.POST.get(f"{prefix}_target_table_name", ""),
+                target_column_name_physical=request.POST.get(f"{prefix}_target_column_name_physical", ""),
+                source_app_code=request.POST.get(f"{prefix}_source_app_code", ""),
+                source_table_name=request.POST.get(f"{prefix}_source_table_name", ""),
+                country_applicability=request.POST.get(f"{prefix}_country_applicability", ""),
+                source_column_name_physical=request.POST.get(f"{prefix}_source_column_name_physical", ""),
+                status='active'
+            )
+
+        messages.success(request, "✅ Changes saved successfully.")
+        return redirect(f"{request.path}?file={selected_file}")
+
+    return render(request, 'mappings/home.html', {
+        'appcode_files': appcode_files,
+        'mappings': mappings,
+        'joins': joins,
+        'selected_file': selected_file
+    })
+
+
+def edit_mapping_file(request, file_name):
+    if 'user_id' not in request.session:
+        return redirect('custom_login')
+
+    mappings = Mappings.objects.filter(uploaded_file=file_name)
+
+    if request.method == 'POST':
+        for mapping in mappings:
+            prefix = f"mapping_{mapping.id}"
+            mapping.source_field = request.POST.get(f"{prefix}_source_field", "")
+            mapping.target_field = request.POST.get(f"{prefix}_target_field", "")
+            mapping.transformation_logic = request.POST.get(f"{prefix}_transformation_logic", "")
+            mapping.save()
+        return redirect('home')
+
+    return render(request, 'mappings/edit_mapping.html', {
+        'file_name': file_name,
+        'mappings': mappings
+    })


### PR DESCRIPTION
## Summary
- add client-side Add Row and Delete controls for join conditions and mapping definitions
- support new and deleted rows in mapping views, marking deletions inactive

## Testing
- `python mapping_portal/manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_688f5f9220908320b841be01da1e292f